### PR TITLE
Mx routing

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -65,5 +65,5 @@ uploadAll=false # if false then messages from Outlook are not uploaded to Sent M
         # options from https://nodejs.org/dist/latest-v16.x/docs/api/tls.html#tls_tls_createsecurecontext_options
         minVersion = "TLSv1"
 
-["modules/zonemta-wildduck".mxRoutes]
-    "*.l.google.com" = "gmail"
+#["modules/zonemta-wildduck".mxRoutes]
+#    "*.l.google.com" = "gmail"

--- a/config.example.toml
+++ b/config.example.toml
@@ -64,3 +64,6 @@ uploadAll=false # if false then messages from Outlook are not uploaded to Sent M
     ["modules/zonemta-wildduck".certs.tlsOptions]
         # options from https://nodejs.org/dist/latest-v16.x/docs/api/tls.html#tls_tls_createsecurecontext_options
         minVersion = "TLSv1"
+
+["modules/zonemta-wildduck".mxRoutes]
+    "*.l.google.com" = "gmail"

--- a/index.js
+++ b/index.js
@@ -467,8 +467,8 @@ module.exports.init = function (app, done) {
         });
     });
 
-    app.addHook('queue:route', async (envelope, routing) => {
-        console.log({ envelope, routing });
+    app.addHook('message:queue', async (envelope, messageInfo) => {
+        console.log('HOOK message:queue', envelope, messageInfo);
     });
 
     // Check if the user can send to yet another recipient

--- a/index.js
+++ b/index.js
@@ -469,6 +469,28 @@ module.exports.init = function (app, done) {
 
     app.addHook('queue:route', async (envelope, routing) => {
         console.log('HOOK queue:route', envelope, routing);
+
+        if (deliveryZone !== 'default') {
+            return;
+        }
+
+        let domain =
+            routing.recipient &&
+            routing.recipient
+                .substring(routing.recipient.indexOf('@') + 1)
+                .toLowerCase()
+                .trim();
+        if (!domain) {
+            return;
+        }
+
+        try {
+            domain = punycode.toASCII(domain);
+        } catch (err) {
+            // ignore
+        }
+
+        console.log('RECIPIENT DOMAIN', domain);
     });
 
     // Check if the user can send to yet another recipient

--- a/index.js
+++ b/index.js
@@ -575,7 +575,7 @@ module.exports.init = function (app, done) {
                 if (matcher([route], mx)) {
                     // MX routing match found!
                     routing.deliveryZone = app.config.mxRoutes[route];
-                    app.logger.error('Main', '%s MXROUTEMATCH recipient=%s mx=%s zone=%s', envelope.id, recipient, mx, app.config.mxRoutes[route]);
+                    app.logger.info('Main', '%s MXROUTEMATCH recipient=%s mx=%s zone=%s', envelope.id, recipient, mx, app.config.mxRoutes[route]);
                     return;
                 }
             }

--- a/index.js
+++ b/index.js
@@ -467,8 +467,8 @@ module.exports.init = function (app, done) {
         });
     });
 
-    app.addHook('message:store', async (envelope, body) => {
-        console.log({ envelope, body });
+    app.addHook('queue:route', async (envelope, routing) => {
+        console.log({ envelope, routing });
     });
 
     // Check if the user can send to yet another recipient

--- a/index.js
+++ b/index.js
@@ -467,6 +467,10 @@ module.exports.init = function (app, done) {
         });
     });
 
+    app.addHook('message:store', async (envelope, body) => {
+        console.log({ envelope, body });
+    });
+
     // Check if the user can send to yet another recipient
     app.addHook('smtp:mail_from', (address, session, next) => {
         if (!checkInterface(session.interface)) {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const SRS = require('srs.js');
 const Gelf = require('gelf');
 const util = require('util');
 const libmime = require('libmime');
+const dns = require('dns');
 
 module.exports.title = 'WildDuck MSA';
 module.exports.init = function (app, done) {
@@ -492,7 +493,18 @@ module.exports.init = function (app, done) {
             // ignore
         }
 
-        console.log('RECIPIENT DOMAIN', domain);
+        try {
+            let exchanges = dns.promises.resolveMx(domain);
+            if (!exchanges || !exchanges.length) {
+                return;
+            }
+
+            let mx = exchanges.sort((a, b) => a.priority - b.priority)[0];
+
+            console.log('RECIPIENT DOMAIN', domain, mx);
+        } catch (err) {
+            // ignore?
+        }
     });
 
     // Check if the user can send to yet another recipient

--- a/index.js
+++ b/index.js
@@ -467,8 +467,8 @@ module.exports.init = function (app, done) {
         });
     });
 
-    app.addHook('message:queue', async (envelope, messageInfo) => {
-        console.log('HOOK message:queue', envelope, messageInfo);
+    app.addHook('queue:route', async (envelope, routing) => {
+        console.log('HOOK queue:route', envelope, routing);
     });
 
     // Check if the user can send to yet another recipient

--- a/index.js
+++ b/index.js
@@ -470,14 +470,16 @@ module.exports.init = function (app, done) {
     app.addHook('queue:route', async (envelope, routing) => {
         console.log('HOOK queue:route', envelope, routing);
 
+        let { recipient, deliveryZone } = routing;
+
         if (deliveryZone !== 'default') {
             return;
         }
 
         let domain =
-            routing.recipient &&
-            routing.recipient
-                .substring(routing.recipient.indexOf('@') + 1)
+            recipient &&
+            recipient
+                .substring(recipient.indexOf('@') + 1)
                 .toLowerCase()
                 .trim();
         if (!domain) {


### PR DESCRIPTION
Added new option to choose delivery zones by MX server.

1. make sure that `zonemta-wildduck` is enabled in "main" state
```
enabled=["receiver", "main", "sender"]
```

2. add routing table with MX hostname patterns

```
["modules/zonemta-wildduck".mxRoutes]
    "*.l.google.com" = "gmail"
```